### PR TITLE
CI to automatically publish to NPM

### DIFF
--- a/.github/scripts/pack.sh
+++ b/.github/scripts/pack.sh
@@ -1,0 +1,9 @@
+# install deps
+yarn
+
+# mark version
+yarn version --new-version "${VERSION}" --no-git-tag-version
+
+# make a package
+mkdir "${GITHUB_WORKSPACE}/dist"
+yarn pack --filename "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}"

--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,0 +1,10 @@
+echo "Publishing fastly-js to NPM"
+echo " Publishing version: ${VERSION}"
+echo " Publish tag is ${PUBLISH_TAG}"
+
+# perform publish
+if [ "${DRY_RUN}" == "1" ]; then
+  echo "(dry run)"
+else
+  yarn publish --tag "${PUBLISH_TAG}"
+fi

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,0 +1,25 @@
+# Parse the release tag
+
+# strip leading 'release/'
+TAG="${RELEASE_TAG#release/}"
+
+# strip leading v
+TAG_VALUE="${TAG#v}"
+
+# detect trailing -dry
+VERSION="${TAG_VALUE%-dry}"
+DRY_RUN=0
+if [ "${TAG_VALUE}" != "${VERSION}" ]; then
+    DRY_RUN=1
+fi
+
+# publish tag ('alpha', 'beta', etc.) is
+PUBLISH_TAG="$(npx -y semver-parser-cli@latest "${VERSION}" --field preid)"
+if [ "${PUBLISH_TAG}" == "undefined" ]; then
+  PUBLISH_TAG=latest
+fi
+
+echo "VERSION=${VERSION}"
+echo "DRY_RUN=${DRY_RUN}"
+echo "PUBLISH_TAG=${PUBLISH_TAG}"
+echo "PACKAGE_FILENAME=fastly-${VERSION}.tgz"

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -6,15 +6,23 @@ TAG="${RELEASE_TAG#release/}"
 # strip leading v
 TAG_VALUE="${TAG#v}"
 
-# detect trailing -dry
+# strip trailing -dry
 VERSION="${TAG_VALUE%-dry}"
+
+# detect valid semver
+VALID_VERSION=$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field matches)
+if [ "${VALID_VERSION}" != "true" ]; then
+  exit 1
+fi
+
+# Detect dry run mode
 DRY_RUN=0
 if [ "${TAG_VALUE}" != "${VERSION}" ]; then
     DRY_RUN=1
 fi
 
 # publish tag ('alpha', 'beta', etc.) is
-PUBLISH_TAG="$(npx -y semver-parser-cli@latest "${VERSION}" --field preid)"
+PUBLISH_TAG="$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field preid)"
 if [ "${PUBLISH_TAG}" == "undefined" ]; then
   PUBLISH_TAG=latest
 fi

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -21,7 +21,7 @@ if [ "${TAG_VALUE}" != "${VERSION}" ]; then
     DRY_RUN=1
 fi
 
-# publish tag ('alpha', 'beta', etc.) is
+# publish tag ('alpha', 'beta', etc.) is used to tag the release
 PUBLISH_TAG="$(npx -y semver-parser-cli@0.2.0 "${VERSION}" --field preid)"
 if [ "${PUBLISH_TAG}" == "undefined" ]; then
   PUBLISH_TAG=latest

--- a/.github/scripts/publish_env.sh
+++ b/.github/scripts/publish_env.sh
@@ -1,7 +1,7 @@
 # Parse the release tag
 
 # strip leading 'release/'
-TAG="${RELEASE_TAG#release/}"
+TAG="${GITHUB_REF_NAME#release/}"
 
 # strip leading v
 TAG_VALUE="${TAG#v}"

--- a/.github/scripts/release_body.sh
+++ b/.github/scripts/release_body.sh
@@ -1,0 +1,25 @@
+printf '%s' "## ${API_CLIENT_NAME} API client v${VERSION}"
+
+if [ "${DRY_RUN}" == "1" ]; then
+  printf '%s' " (dry run)"
+fi
+
+echo ""
+
+# add a newline
+echo ""
+
+CODE_PATH=${CODE_PATH:-./}
+G_CODE=$(jq -r .G "${CODE_PATH}/sig.json")
+D_CODE=$(jq -r .D "${CODE_PATH}/sig.json")
+
+PACKAGE_FILESIZE=$(ls -lh "${GITHUB_WORKSPACE}/dist/${PACKAGE_FILENAME}" | awk '{print $5}')B
+
+echo "Artifact"
+echo " ${PACKAGE_FILENAME} (${PACKAGE_FILESIZE})"
+echo ""
+echo "Generated on: $(date)"
+echo "G-code: ${G_CODE}, D-code: ${D_CODE}"
+if [ "${PUBLISH_TAG}" != "latest" ]; then
+  echo "Pre-release Tag: ${PUBLISH_TAG}"
+fi

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -5,7 +5,7 @@ on:
       - 'release/v?[0-9]*'
 
 env:
-  RELEASE_TAG: ${{ github.ref_name }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
 
 jobs:
   publish:

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,0 +1,48 @@
+name: Release CI
+on:
+  push:
+    tags:
+      - 'release/v?[0-9]*'
+
+env:
+  RELEASE_TAG: ${{ github.ref_name }}
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Set up environment variables
+        run: ./.github/scripts/publish_env.sh >> $GITHUB_ENV
+        working-directory: ./main
+        shell: bash
+      - name: Pack API client
+        run: ./.github/scripts/pack.sh
+        working-directory: ./main
+        shell: bash
+      - name: Auth with NPM
+        run: npm config set "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_PUBLISH_TOKEN }}"
+      - name: Publish API client
+        run: ./.github/scripts/publish.sh
+        working-directory: ./main
+        shell: bash
+      - name: Write release body file
+        run: API_CLIENT_NAME=JavaScript CODE_PATH=./main ./main/.github/scripts/release_body.sh > ./dist/release_body.txt
+        shell: bash
+      - name: Create release (dry run)
+        if: ${{ env.DRY_RUN == '1' }}
+        run: cat ./dist/release_body.txt
+      - name: Create GitHub release
+        if: ${{ env.DRY_RUN != '1' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          name: v${{ env.VERSION }}
+          body_path: ./dist/release_body.txt
+          files: |
+            ./dist/${{ env.PACKAGE_FILENAME }}
+          draft: false
+          prerelease: ${{ env.PUBLISH_TAG != 'latest' }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fs": false
   },
   "engines": {
-    "node": "^16"
+    "node": ">= 16.0.0"
   },
   "dependencies": {
     "superagent": "^6.1.0"


### PR DESCRIPTION
This PR adds a publish mechanism to allow this API client to publish itself to NPM and create a release in GitHub.

The input is to create a tag in this repo and push it, with the syntax: `release/[VERSION][-dry]`.

- `VERSION` should be the version number that the package should be published under, such as `v3.0.1` or `3.0.1-alpha.0` (leading `v` is optional and ignored)
- Specify `-dry` if you want to do a "dry run" which doesn't actually publish to NPM or create a release

This CI is intended to be used along with the client generator project, whose job it is to generate the newest API client code, tag it with said version code, and push it to this repo.

Unless running in `-dry` mode, this CI step will create a real version in NPM, and a release in GitHub. Example run using `release/v3.0.1-alpha.0` has generated the following:
 - CI run: https://github.com/fastly/fastly-js/actions/runs/3672072671
 - NPM release: https://www.npmjs.com/package/fastly/v/3.0.1-alpha.0
   - If the version number contains a prerelease id (such as `alpha` in this case), then it is tagged in NPM with that ID. This has been done to ensure that a normal `npm install fastly` (which implies `npm install fastly@latest`) won't install it. To install it you'd have to specify either the specific version (`npm install fastly@3.0.1-alpha.0`) or the tag (`npm install fastly@alpha`).
 - GitHub release: https://github.com/fastly/fastly-js/releases/tag/release%2Fv3.0.1-alpha.0
 - Artifact (node package tarball): https://github.com/fastly/fastly-js/releases/download/release%2Fv3.0.1-alpha.0/fastly-3.0.1-alpha.0.tgz
   - Note the artifact is added to the GitHub release as a release asset

If running in `-dry` mode, no actual NPM publish or release will be made. Example run using `release/v3.0.1-alpha.0-dry`:
 - CI run: https://github.com/fastly/fastly-js/actions/runs/3675429106
   - Click through this link into the "Publish to NPM" job, and read the output of the "Create Release (Dry Run)" step. You'll see the following output:
      ```
      ## JavaScript API client v3.0.1-alpha.0 (dry run)
      
      Artifact
       fastly-3.0.1-alpha.0.tgz (298KB)
      
      Generated on: Mon Dec 12 11:44:47 UTC 2022
      G-code: 8b4af0da, D-code: 237fa474
      Pre-release Tag: alpha
      ```

This CI relies on an npmjs.com "granular" access token https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-granular-access-tokens-on-the-website with publish access to the `fastly` package. This token is stored as a repository secret under the name `NPM_PUBLISH_TOKEN`. This type of token has a maximum life of 365 days and must be refreshed periodically.